### PR TITLE
fix: 🩹 "++i" statement is not so bad

### DIFF
--- a/src/main/java/fr/greencodeinitiative/java/checks/IncrementCheck.java
+++ b/src/main/java/fr/greencodeinitiative/java/checks/IncrementCheck.java
@@ -45,4 +45,10 @@ class IncrementCheck {
             System.out.println(i);
         }
     }
+
+    // Compliant because maybe foo51 needs the incremented value
+    void foo6(int value) {
+        int i = 0;
+        foo51(i++);
+    }
 }


### PR DESCRIPTION
In some cases, postfix increment may be intentional. (related to same branch in ecocode-java repository)

Closes #4